### PR TITLE
Default values.yaml for ArgoCD helm on spoke

### DIFF
--- a/gitops/fleet/charts/argo-cd/values.yaml
+++ b/gitops/fleet/charts/argo-cd/values.yaml
@@ -1,0 +1,3 @@
+server:
+  service:
+    type: LoadBalancer

--- a/terraform/spokes/destroy.sh
+++ b/terraform/spokes/destroy.sh
@@ -50,11 +50,6 @@ if [ -n "$VPCID" ]; then
             aws ec2 delete-vpc-endpoints --vpc-endpoint-ids "$endpoint_exists"
         fi
     done
-
-
-    echo "Cleaning VPC $VPCID"
-    aws-delete-vpc -vpc-id=$VPCID
-
 else
     echo "VPC with tag Name=fleet-spoke-${env} not found"
 fi 

--- a/terraform/spokes/destroy.sh
+++ b/terraform/spokes/destroy.sh
@@ -26,7 +26,7 @@ terraform -chdir=$SCRIPTDIR output -raw configure_kubectl > "$TMPFILE"
 if [[ ! $(cat $TMPFILE) == *"No outputs found"* ]]; then
   source "$TMPFILE"
   scale_down_karpenter_nodes
-  kubectl delete svc -n argocd -l app.kubernetes.io/component=server
+  kubectl delete svc -n kube-fleet -l app.kubernetes.io/component=server
   # metric server leaves this behind
   kubectl delete apiservices.apiregistration.k8s.io v1beta1.metrics.k8s.io
 fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding default values.yaml for ArgoCD helm release run on spoke clusters. For now, it only changes the type of the service to LoadBalancer to expose the UI so attendees can easily explore it during the workshop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
