### PR TITLE
Fix destroy.sh to delete karpenter node correctly

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -8,10 +8,11 @@ DEBUG="${DEBUG:-}"
 [[ -n "${DEBUG:-}" ]] && set -x
 set -u
 
-DEBUG=$DEBUG ${ROOTDIR}/terraform/common/destroy.sh
+
 DEBUG=$DEBUG ${ROOTDIR}/terraform/hub/destroy.sh
 DEBUG=$DEBUG ${ROOTDIR}/terraform/spokes/destroy.sh staging
 DEBUG=$DEBUG ${ROOTDIR}/terraform/spokes/destroy.sh prod
+DEBUG=$DEBUG ${ROOTDIR}/terraform/common/destroy.sh
 
 
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -8,10 +8,13 @@ DEBUG="${DEBUG:-}"
 [[ -n "${DEBUG:-}" ]] && set -x
 set -u
 
-DEBUG=$DEBUG ${ROOTDIR}/terraform/spokes/destroy.sh prod
-DEBUG=$DEBUG ${ROOTDIR}/terraform/spokes/destroy.sh staging
-DEBUG=$DEBUG ${ROOTDIR}/terraform/hub/destroy.sh
 DEBUG=$DEBUG ${ROOTDIR}/terraform/common/destroy.sh
+DEBUG=$DEBUG ${ROOTDIR}/terraform/hub/destroy.sh
+DEBUG=$DEBUG ${ROOTDIR}/terraform/spokes/destroy.sh staging
+DEBUG=$DEBUG ${ROOTDIR}/terraform/spokes/destroy.sh prod
+
+
+
 
 
 

--- a/gitops/addons/charts/cw-prometheus/templates/prometheus-eks.yaml
+++ b/gitops/addons/charts/cw-prometheus/templates/prometheus-eks.yaml
@@ -219,7 +219,7 @@ data:
                     "^karpenter_nodes_terminated$"
                   ]
                 },
-                {								
+                {
                   "source_labels": ["job"],
                   "label_matcher": "^karpenter$",
                   "dimensions": [
@@ -538,7 +538,6 @@ spec:
               mountPath: /etc/cwagentconfig
             - name: prometheus-config
               mountPath: /etc/prometheusconfig
-
       volumes:
         - name: prometheus-cwagentconfig
           configMap:
@@ -548,3 +547,7 @@ spec:
             name: prometheus-config
       terminationGracePeriodSeconds: 60
       serviceAccountName: cwagent-prometheus
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/gitops/addons/charts/cw-prometheus/values.yaml
+++ b/gitops/addons/charts/cw-prometheus/values.yaml
@@ -1,0 +1,1 @@
+tolerations: []

--- a/gitops/addons/default/addons/cni-metrics-helper/values.yaml
+++ b/gitops/addons/default/addons/cni-metrics-helper/values.yaml
@@ -1,4 +1,3 @@
-# values for the addon
 tolerations:
   - key: CriticalAddonsOnly
     operator: Exists

--- a/gitops/addons/default/addons/cw-prometheus/values.yaml
+++ b/gitops/addons/default/addons/cw-prometheus/values.yaml
@@ -1,0 +1,3 @@
+tolerations:
+- key: "CriticalAddonsOnly"
+  operator: "Exists"

--- a/gitops/addons/default/addons/external-secrets/values.yaml
+++ b/gitops/addons/default/addons/external-secrets/values.yaml
@@ -1,0 +1,4 @@
+global:
+  tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists

--- a/gitops/addons/default/addons/kyverno/values.yaml
+++ b/gitops/addons/default/addons/kyverno/values.yaml
@@ -1,6 +1,67 @@
 # Kyverno Helm chart values
 # this snipped includes only the changeset
 
+
+crds:
+  migration:
+    tolerations:
+    - key: "CriticalAddonsOnly"
+      operator: "Exists"
+
+admissionController:
+  tolerations:
+  - key: "CriticalAddonsOnly"
+    operator: "Exists"
+
+backgroundController:
+  tolerations:
+  - key: "CriticalAddonsOnly"
+    operator: "Exists"
+
+cleanupController:
+  tolerations:
+  - key: "CriticalAddonsOnly"
+    operator: "Exists"
+
+reportsController:
+  tolerations:
+  - key: "CriticalAddonsOnly"
+    operator: "Exists"
+
+webhooksCleanup:
+  tolerations:
+  - key: "CriticalAddonsOnly"
+    operator: "Exists"
+
+cleanupJobs:
+  admissionReports:
+    tolerations:
+    - key: "CriticalAddonsOnly"
+      operator: "Exists"
+
+cleanupJobs:
+  clusterAdmissionReports:
+    tolerations:
+    - key: "CriticalAddonsOnly"
+      operator: "Exists"
+
+cleanupJobs:
+  updateRequests:
+    tolerations:
+    - key: "CriticalAddonsOnly"
+      operator: "Exists"
+
+cleanupJobs:
+  ephemeralReports:
+    tolerations:
+    - key: "CriticalAddonsOnly"
+      operator: "Exists"
+
+policyReportsCleanup:
+  tolerations:
+  - key: "CriticalAddonsOnly"
+    operator: "Exists"
+
 # This configuration installs with the "default" value 10 PSP based policies in audit mode.
 # This improves your cluster security without additional effort.
 #

--- a/gitops/addons/default/addons/metrics-server/values.yaml
+++ b/gitops/addons/default/addons/metrics-server/values.yaml
@@ -1,1 +1,4 @@
 # values for the addon
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists

--- a/gitops/fleet/bootstrap/control-plane/members-init/fleet-members-manifests-appset.yaml
+++ b/gitops/fleet/bootstrap/control-plane/members-init/fleet-members-manifests-appset.yaml
@@ -19,6 +19,9 @@ spec:
   template:
     metadata:
       name: 'fleet-members-{{.name}}'
+      finalizers:
+      # This is here only for workshop purposes. In a real-world scenario, you should not use this
+      - resources-finalizer.argocd.argoproj.io
     spec:
       project: default
       sources:

--- a/gitops/fleet/bootstrap/members-manifests/fleet-cluster-addons-gitops-bridge-appset.yaml
+++ b/gitops/fleet/bootstrap/members-manifests/fleet-cluster-addons-gitops-bridge-appset.yaml
@@ -18,7 +18,10 @@ spec:
           addonChart: gitops-bridge
   template:
     metadata:
-      name: 'cluster-addons-{{.name}}'
+      name: 'cluster-addons'
+      finalizers:
+      # This is here only for workshop purposes. In a real-world scenario, you should not use this
+      - resources-finalizer.argocd.argoproj.io
     spec:
       project: default
       sources:

--- a/gitops/fleet/bootstrap/members-manifests/fleet-cluster-platform-appset.yaml
+++ b/gitops/fleet/bootstrap/members-manifests/fleet-cluster-platform-appset.yaml
@@ -19,6 +19,9 @@ spec:
   template:
     metadata:
       name: 'platform'
+      finalizers:
+      # This is here only for workshop purposes. In a real-world scenario, you should not use this
+      - resources-finalizer.argocd.argoproj.io
     spec:
       project: default
       source:

--- a/gitops/platform/bootstrap/teams/namespaces-appset.yaml
+++ b/gitops/platform/bootstrap/teams/namespaces-appset.yaml
@@ -29,6 +29,9 @@ spec:
         team: '{{path.basename}}'
         workloads: 'true'
         namespaces: 'true'
+      finalizers:
+      # This is here only for workshop purposes. In a real-world scenario, you should not use this
+      - resources-finalizer.argocd.argoproj.io
     spec:
       project: default
       source:

--- a/gitops/platform/bootstrap/workloads/web-store-backend-appset.yaml
+++ b/gitops/platform/bootstrap/workloads/web-store-backend-appset.yaml
@@ -14,7 +14,7 @@ spec:
                 matchExpressions:
                   - key: environment
                     operator: In
-                    values: [staging]
+                    values: [staging, prod]
               values:
                 team: backend
           - git:

--- a/gitops/platform/bootstrap/workloads/web-store-backend-appset.yaml
+++ b/gitops/platform/bootstrap/workloads/web-store-backend-appset.yaml
@@ -31,6 +31,9 @@ spec:
         team: '{{values.team}}'
         component: '{{path.basename}}'
         workloads: 'true'
+      finalizers:
+      # This is here only for workshop purposes. In a real-world scenario, you should not use this
+      - resources-finalizer.argocd.argoproj.io
     spec:
       project: '{{values.team}}'
       source:

--- a/gitops/platform/bootstrap/workloads/web-store-frontend-appset.yaml
+++ b/gitops/platform/bootstrap/workloads/web-store-frontend-appset.yaml
@@ -31,6 +31,9 @@ spec:
         team: '{{values.team}}'
         component: '{{path.basename}}'
         workloads: 'true'
+      finalizers:
+      # This is here only for workshop purposes. In a real-world scenario, you should not use this
+      - resources-finalizer.argocd.argoproj.io
     spec:
       project: '{{values.team}}'
       source:

--- a/gitops/platform/bootstrap/workloads/web-store-frontend-appset.yaml
+++ b/gitops/platform/bootstrap/workloads/web-store-frontend-appset.yaml
@@ -14,7 +14,7 @@ spec:
                 matchExpressions:
                   - key: environment
                     operator: In
-                    values: [staging]
+                    values: [staging, prod]
               values:
                 team: frontend
           - git:

--- a/terraform/common.sh
+++ b/terraform/common.sh
@@ -6,70 +6,19 @@ set -uo pipefail
 
 
 scale_down_karpenter_nodes() {
-  # This function will scale down all deployments and statefulsets running on the nodes with the label karpenter.sh/registered=true
-  echo "Scaling down deployments and statefulsets on nodes with karpenter.sh/registered=true label"
-
-  # Get all nodes with the label karpenter.sh/registered=true
-  nodes=$(kubectl get nodes -l karpenter.sh/registered=true -o jsonpath='{.items[*].metadata.name}')
-
-  # Iterate over each node
-  for node in $nodes; do
-    # Get all pods running on the current node
-    pods=$(kubectl get pods --all-namespaces --field-selector spec.nodeName=$node -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}')
-
-    # Iterate over each pod
-    while IFS= read -r pod; do
-      namespace=$(echo $pod | awk '{print $1}')
-      # skip if namespace is argocd, usefull for the gitops bridge debugging
-      if [[ $namespace == "argocd" ]]; then
-        echo "Skipping pod $pod in namespace $namespace"
-        continue
-      fi
-      pod_name=$(echo $pod | awk '{print $2}')
-
-
-      # Get the owner references of the pod
-      owner_refs=$(kubectl get pod $pod_name -n $namespace -o jsonpath='{.metadata.ownerReferences[*]}')
-
-      # Check if the owner is a ReplicaSet (which is part of a deployment) or a StatefulSet and scale down
-      if echo $owner_refs | grep -q "ReplicaSet"; then
-      replicaset_name=$(kubectl get pod $pod_name -n $namespace -o jsonpath='{.metadata.ownerReferences[?(@.kind=="ReplicaSet")].name}')
-      deployment_name=$(kubectl get replicaset $replicaset_name -n $namespace -o jsonpath='{.metadata.ownerReferences[?(@.kind=="Deployment")].name}')
-      if [[ $(kubectl get deployment $deployment_name -n $namespace -o jsonpath='{.spec.replicas}') -gt 0 ]]; then
-        echo kubectl scale deployment $deployment_name -n $namespace --replicas=0
-        kubectl scale deployment $deployment_name -n $namespace --replicas=0
-        kubectl rollout status deployment $deployment_name -n $namespace
-      fi
-      elif echo $owner_refs | grep -q "StatefulSet"; then
-      statefulset_name=$(kubectl get pod $pod_name -n $namespace -o jsonpath='{.metadata.ownerReferences[?(@.kind=="StatefulSet")].name}')
-      if [[ $(kubectl get statefulset $statefulset_name -n $namespace -o jsonpath='{.spec.replicas}') -gt 0 ]]; then
-        echo kubectl scale statefulset $statefulset_name -n $namespace --replicas=0
-        kubectl scale statefulset $statefulset_name -n $namespace --replicas=0
-        kubectl rollout status statefulset $statefulset_name -n $namespace
-      fi
-      fi
-    done <<< "$pods"
-  done
 
   # Delete the nodeclaims
+  echo "Deleting Karpeneter NodePools"
   kubectl delete nodepools.karpenter.sh --all
-  kubectl delete nodeclaims.karpenter.sh --all
-
-
   # do a final check to make sure the nodes are gone, loop sleep 60 in between checks
   nodes=$(kubectl get nodes -l karpenter.sh/registered=true -o jsonpath='{.items[*].metadata.name}')
   while [[ ! -z $nodes ]]; do
-    # Loop through each node and delete it
-    for node in $nodes; do
-        echo "Deleting node: $node"
-        kubectl delete node $node
-    done
+    kubectl delete nodepools.karpenter.sh --all
     echo "Waiting for nodes to be deleted: $nodes"
     sleep 60
     nodes=$(kubectl get nodes -l karpenter.sh/registered=true -o jsonpath='{.items[*].metadata.name}')
   done
-  echo "Waiting for karpenter nodes to be deleted up to 2 minutes"
-  sleep 120
+
 
 
 }

--- a/terraform/hub/bootstrap/addons.yaml
+++ b/terraform/hub/bootstrap/addons.yaml
@@ -19,6 +19,9 @@ spec:
   template:
     metadata:
       name: cluster-addons
+      finalizers:
+      # This is here only for workshop purposes. In a real-world scenario, you should not use this
+      - resources-finalizer.argocd.argoproj.io
     spec:
       project: default
       sources:
@@ -45,7 +48,7 @@ spec:
         name: '{{.name}}'
       syncPolicy:
         automated:
-          selfHeal: true
+          selfHeal: false
           allowEmpty: true
           prune: false
         retry:

--- a/terraform/hub/destroy.sh
+++ b/terraform/hub/destroy.sh
@@ -16,6 +16,8 @@ terraform -chdir=$SCRIPTDIR output -raw configure_kubectl > "$TMPFILE"
 # check if TMPFILE contains the string "No outputs found"
 if [[ ! $(cat $TMPFILE) == *"No outputs found"* ]]; then
   source "$TMPFILE"
+fi
+if kubectl get nodes; then
   kubectl delete --cascade='foreground' applicationsets.argoproj.io -n argocd cluster-addons
   kubectl delete --cascade='foreground' applicationsets.argoproj.io -n argocd fleet-control-plane
   kubectl delete --cascade='foreground' applicationsets.argoproj.io -n argocd fleet-members-init

--- a/terraform/hub/main.tf
+++ b/terraform/hub/main.tf
@@ -103,7 +103,7 @@ locals {
     enable_keda                            = try(var.addons.enable_keda, false)
     enable_kyverno                         = try(var.addons.enable_kyverno, false)
     enable_kyverno_policy_reporter         = try(var.addons.enable_kyverno_policy_reporter, false)
-    enable_kyverno_policies                = try(var.addons.enable_kyverno_policies, false)  
+    enable_kyverno_policies                = try(var.addons.enable_kyverno_policies, false)
     enable_kube_prometheus_stack           = try(var.addons.enable_kube_prometheus_stack, false)
     enable_metrics_server                  = try(var.addons.enable_metrics_server, false)
     enable_prometheus_adapter              = try(var.addons.enable_prometheus_adapter, false)
@@ -112,7 +112,7 @@ locals {
   }
   addons = merge(
     #
-    # GitOps bridge does not use enable_XXXXX labels on the cluster secret in argocd. 
+    # GitOps bridge does not use enable_XXXXX labels on the cluster secret in argocd.
     # Labels are removed to avoid confusion
     #
     #local.aws_addons,
@@ -183,7 +183,7 @@ locals {
   argocd_apps = {
     addons    = file("${path.module}/bootstrap/addons.yaml")
     fleet    = file("${path.module}/bootstrap/fleet.yaml")
-    #workload    = file("${path.module}/bootstrap/workload.yaml")    
+    #workload    = file("${path.module}/bootstrap/workload.yaml")
   }
 
   tags = {
@@ -337,13 +337,13 @@ module "eks" {
       min_size     = 2
       max_size     = 6
       desired_size = 2
-      # taints = local.aws_addons.enable_karpenter ? {
-      #   dedicated = {
-      #     key    = "CriticalAddonsOnly"
-      #     operator   = "Exists"
-      #     effect    = "NO_SCHEDULE"
-      #   }
-      # } : {}
+      taints = local.aws_addons.enable_karpenter ? {
+        dedicated = {
+          key    = "CriticalAddonsOnly"
+          operator   = "Exists"
+          effect    = "NO_SCHEDULE"
+        }
+      } : {}
     }
   }
 
@@ -391,7 +391,7 @@ module "eks" {
         type                          = "ingress"
         source_cluster_security_group = true
       }
-    }  
+    }
   node_security_group_tags = merge(local.tags, {
     # NOTE - if creating multiple security groups with this module, only tag the
     # security group that Karpenter should utilize with the following tag

--- a/terraform/hub/pod-identity.tf
+++ b/terraform/hub/pod-identity.tf
@@ -171,7 +171,7 @@ resource "aws_eks_pod_identity_association" "argocd_server" {
 # VPC CNI Helper
 ################################################################################
 resource "aws_iam_policy" "cni_metrics_helper_pod_identity_policy" {
-  name        = "cni_metrics_helper_pod_identity_policy-${terraform.workspace}"
+  name_prefix = "cni_metrics_helper_pod_identity"
   path        = "/"
   description = "Policy to allow cni metrics helper put metcics to cloudwatch"
 
@@ -195,11 +195,11 @@ module "cni_metrics_helper_pod_identity" {
   source = "terraform-aws-modules/eks-pod-identity/aws"
   version = "~> 1.4.0"
   name = "cni-metrics-helper"
-  
+
   additional_policy_arns = {
     "cni-metrics-help" : aws_iam_policy.cni_metrics_helper_pod_identity_policy.arn
-  } 
-  
+  }
+
   # Pod Identity Associations
   associations = {
     addon = {

--- a/terraform/spokes/destroy.sh
+++ b/terraform/spokes/destroy.sh
@@ -25,6 +25,8 @@ terraform -chdir=$SCRIPTDIR output -raw configure_kubectl > "$TMPFILE"
 # check if TMPFILE contains the string "No outputs found"
 if [[ ! $(cat $TMPFILE) == *"No outputs found"* ]]; then
   source "$TMPFILE"
+fi
+if kubectl get nodes; then
   # wait until all the argocd applications are gone from the namespace argocd
   # To know if all argocd apps are gone we need to parse the output of kubectl get applications.argocd -n argocd and check if it contains "No resources found"
   while [[ $(kubectl get applications.argoproj.io -n argocd 2>&1) != *"No resources found"* ]]; do

--- a/terraform/spokes/destroy.sh
+++ b/terraform/spokes/destroy.sh
@@ -29,7 +29,7 @@ if [[ ! $(cat $TMPFILE) == *"No outputs found"* ]]; then
   # To know if all argocd apps are gone we need to parse the output of kubectl get applications.argocd -n argocd and check if it contains "No resources found"
   while [[ $(kubectl get applications.argoproj.io -n argocd 2>&1) != *"No resources found"* ]]; do
     echo "Waiting for all argocd applications to be deleted by hub cluster destroy.sh: https://github.com/aws-samples/fleet-management-on-amazon-eks-workshop/blob/riv24/terraform/hub/destroy.sh"
-    sleep 5
+    sleep 60
   done
 
   scale_down_karpenter_nodes

--- a/terraform/spokes/destroy.sh
+++ b/terraform/spokes/destroy.sh
@@ -29,10 +29,14 @@ fi
 if kubectl get nodes; then
   # wait until all the argocd applications are gone from the namespace argocd
   # To know if all argocd apps are gone we need to parse the output of kubectl get applications.argocd -n argocd and check if it contains "No resources found"
-  while [[ $(kubectl get applications.argoproj.io -n argocd 2>&1) != *"No resources found"* ]]; do
-    echo "Waiting for all argocd applications to be deleted by hub cluster destroy.sh: https://github.com/aws-samples/fleet-management-on-amazon-eks-workshop/blob/riv24/terraform/hub/destroy.sh"
-    sleep 60
-  done
+  if kubectl get crd applications.argoproj.io; then
+
+    while [[ $(kubectl get applications.argoproj.io -n argocd 2>&1) != *"No resources found"* ]]; do
+      echo "Waiting for all argocd applications to be deleted by hub cluster destroy.sh: https://github.com/aws-samples/fleet-management-on-amazon-eks-workshop/blob/riv24/terraform/hub/destroy.sh"
+      sleep 60
+    done
+
+  fi
 
   scale_down_karpenter_nodes
   # delete all load balancers

--- a/terraform/spokes/destroy.sh
+++ b/terraform/spokes/destroy.sh
@@ -25,18 +25,21 @@ terraform -chdir=$SCRIPTDIR output -raw configure_kubectl > "$TMPFILE"
 # check if TMPFILE contains the string "No outputs found"
 if [[ ! $(cat $TMPFILE) == *"No outputs found"* ]]; then
   source "$TMPFILE"
-  kubectl delete applicationsets.argoproj.io -n argocd web-store-backend
-  kubectl delete applicationsets.argoproj.io -n argocd web-store-frontend
+  # wait until all the argocd applications are gone from the namespace argocd
+  # To know if all argocd apps are gone we need to parse the output of kubectl get applications.argocd -n argocd and check if it contains "No resources found"
+  while [[ $(kubectl get applications.argoproj.io -n argocd 2>&1) != *"No resources found"* ]]; do
+    echo "Waiting for all argocd applications to be deleted by hub cluster destroy.sh: https://github.com/aws-samples/fleet-management-on-amazon-eks-workshop/blob/riv24/terraform/hub/destroy.sh"
+    sleep 5
+  done
+
   scale_down_karpenter_nodes
   # delete all load balancers
   kubectl get services --all-namespaces -o custom-columns="NAME:.metadata.name,NAMESPACE:.metadata.namespace,TYPE:.spec.type" | \
   grep LoadBalancer | \
   while read -r name namespace type; do
     echo "Deleting service $name in namespace $namespace of type $type"
-    kubectl delete service "$name" -n "$namespace"
+    kubectl delete --cascade='foreground' service "$name" -n "$namespace"
   done
-  # metric server leaves this behind
-  kubectl delete apiservices.apiregistration.k8s.io v1beta1.metrics.k8s.io
 fi
 
 terraform -chdir=$SCRIPTDIR destroy -target="module.gitops_bridge_bootstrap_hub" -auto-approve -var-file="workspaces/${env}.tfvars"

--- a/terraform/spokes/destroy.sh
+++ b/terraform/spokes/destroy.sh
@@ -25,6 +25,8 @@ terraform -chdir=$SCRIPTDIR output -raw configure_kubectl > "$TMPFILE"
 # check if TMPFILE contains the string "No outputs found"
 if [[ ! $(cat $TMPFILE) == *"No outputs found"* ]]; then
   source "$TMPFILE"
+  kubectl delete applicationsets.argoproj.io -n argocd web-store-backend
+  kubectl delete applicationsets.argoproj.io -n argocd web-store-frontend
   scale_down_karpenter_nodes
   # delete all load balancers
   kubectl get services --all-namespaces -o custom-columns="NAME:.metadata.name,NAMESPACE:.metadata.namespace,TYPE:.spec.type" | \

--- a/terraform/spokes/main.tf
+++ b/terraform/spokes/main.tf
@@ -68,7 +68,7 @@ locals {
     enable_aws_argocd                            = try(var.addons.enable_aws_argocd , false)
     enable_cw_prometheus                         = try(var.addons.enable_cw_prometheus, false)
     enable_cni_metrics_helper                    = try(var.addons.enable_cni_metrics_helper, false)
-    
+
   }
   oss_addons = {
     enable_argocd                          = try(var.addons.enable_argocd, false)
@@ -82,7 +82,7 @@ locals {
     enable_keda                            = try(var.addons.enable_keda, false)
     enable_kyverno                         = try(var.addons.enable_kyverno, false)
     enable_kyverno_policy_reporter         = try(var.addons.enable_kyverno_policy_reporter, false)
-    enable_kyverno_policies                = try(var.addons.enable_kyverno_policies, false)      
+    enable_kyverno_policies                = try(var.addons.enable_kyverno_policies, false)
     enable_kube_prometheus_stack           = try(var.addons.enable_kube_prometheus_stack, false)
     enable_metrics_server                  = try(var.addons.enable_metrics_server, false)
     enable_prometheus_adapter              = try(var.addons.enable_prometheus_adapter, false)
@@ -91,7 +91,7 @@ locals {
   }
   addons = merge(
     #
-    # GitOps bridge does not use enable_XXXXX labels on the cluster secret in argocd. 
+    # GitOps bridge does not use enable_XXXXX labels on the cluster secret in argocd.
     # Labels are removed to avoid confusion
     #
     #local.aws_addons,
@@ -265,13 +265,13 @@ module "eks" {
       max_size     = 6
       desired_size = 2
 
-      # taints = local.aws_addons.enable_karpenter ? {
-      #   dedicated = {
-      #     key    = "CriticalAddonsOnly"
-      #     operator   = "Exists"
-      #     effect    = "NO_SCHEDULE"
-      #   }
-      # } : {}
+      taints = local.aws_addons.enable_karpenter ? {
+        dedicated = {
+          key    = "CriticalAddonsOnly"
+          operator   = "Exists"
+          effect    = "NO_SCHEDULE"
+        }
+      } : {}
     }
   }
 
@@ -319,7 +319,7 @@ module "eks" {
         type                          = "ingress"
         source_cluster_security_group = true
       }
-    }    
+    }
   node_security_group_tags = merge(local.tags, {
     # NOTE - if creating multiple security groups with this module, only tag the
     # security group that Karpenter should utilize with the following tag

--- a/terraform/spokes/outputs.tf
+++ b/terraform/spokes/outputs.tf
@@ -6,3 +6,28 @@ output "configure_kubectl" {
   EOT
 }
 
+output "configure_argocd" {
+  description = "Terminal Setup"
+  value       = <<-EOT
+    export KUBECONFIG="/tmp/${module.eks.cluster_name}"
+    aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name}
+    export ARGOCD_OPTS="--port-forward --port-forward-namespace argocd --grpc-web"
+    kubectl config set-context --current --namespace argocd
+    argocd login --port-forward --username admin --password $(argocd admin initial-password | head -1)
+    echo "ArgoCD Username: admin"
+    echo "ArgoCD Password: $(kubectl get secrets argocd-initial-admin-secret -n argocd --template="{{index .data.password | base64decode}}")"
+    echo Port Forward: http://localhost:8080
+    kubectl port-forward -n argocd svc/argocd-server 8080:80
+    EOT
+}
+
+output "access_argocd" {
+  description = "ArgoCD Access"
+  value       = <<-EOT
+    export KUBECONFIG="/tmp/${module.eks.cluster_name}"
+    aws eks --region ${local.region} update-kubeconfig --name ${module.eks.cluster_name}
+    echo "ArgoCD Username: admin"
+    echo "ArgoCD Password: $(kubectl get secrets argocd-initial-admin-secret -n argocd --template="{{index .data.password | base64decode}}")"
+    echo "ArgoCD URL: https://$(kubectl get svc -n argocd argocd-server -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
+    EOT
+}

--- a/terraform/spokes/pod-identity.tf
+++ b/terraform/spokes/pod-identity.tf
@@ -156,7 +156,7 @@ module "karpenter" {
 # VPC CNI Helper
 ################################################################################
 resource "aws_iam_policy" "cni_metrics_helper_pod_identity_policy" {
-  name        = "cni_metrics_helper_pod_identity_policy-${terraform.workspace}"
+  name_prefix = "cni_metrics_helper_pod_identity"
   path        = "/"
   description = "Policy to allow cni metrics helper put metcics to cloudwatch"
 
@@ -180,11 +180,11 @@ module "cni_metrics_helper_pod_identity" {
   source = "terraform-aws-modules/eks-pod-identity/aws"
   version = "~> 1.4.0"
   name = "cni-metrics-helper-${terraform.workspace}"
-  
+
   additional_policy_arns = {
     "cni-metrics-help" : aws_iam_policy.cni_metrics_helper_pod_identity_policy.arn
-  } 
-  
+  }
+
   # Pod Identity Associations
   associations = {
     addon = {


### PR DESCRIPTION
- Adding finalizers to appset gitops-bridge to remove cluster-addons argocd applications, but leaving the resources on the cluster
- Adding finalizers to workloads webstore to remove the app argocd applications and the resources with it
- Add tolerations to all cluster-addons so they run on node-groups, leaving only the application running in karpenter
- enable prod for the 2 appset for webstore
- made the cni metric helper policy use name_prefix in terraform
