### PR TITLE
update hub to 1.30

### DIFF
--- a/gitops/addons/charts/gitops-bridge/values.yaml
+++ b/gitops/addons/charts/gitops-bridge/values.yaml
@@ -775,7 +775,7 @@ addons:
         valuesObject:
           AMP_ENDPOINT_URL: '{{.metadata.annotations.amp_endpoint_url}}'
           AMP_AWS_REGION: '{{.metadata.annotations.aws_region}}'
-          
+
   kyverno:
     enabled: false
     releaseName: kyverno
@@ -899,10 +899,10 @@ addons:
   prometheus_node_exporter:
     enabled: false
     releaseName: prometheus-node-exporter
-    namespace: '{{default "prometheus-node-exporter" (index .metadata.annotations "prometheus_node_exporter_namespace")}}'
+    namespace: '{{default "kube-prometheus-stack" (index .metadata.annotations "prometheus_node_exporter_namespace")}}'
     chart: prometheus-node-exporter
     repoUrl: https://prometheus-community.github.io/helm-charts
-    targetRevision: "4.24.0"
+    targetRevision: "4.39.0"
     selector:
       matchExpressions:
         - key: enable_prometheus_node_exporter

--- a/terraform/hub/variables.tf
+++ b/terraform/hub/variables.tf
@@ -7,7 +7,7 @@ variable "vpc_cidr" {
 variable "kubernetes_version" {
   description = "Kubernetes version"
   type        = string
-  default     = "1.29"
+  default     = "1.30"
 }
 
 variable "kms_key_admin_roles" {


### PR DESCRIPTION
- EKS for hub cluster set version to 1.30
- Update gitops-bridge chart to deploy node-exporter to kube-promtheus-stack namespace with latest version
