### PR TITLE
Make nodepool dynamic in karpenter dashboard and add defaults

### DIFF
--- a/terraform/hub/cw-dashboard-coredns.json
+++ b/terraform/hub/cw-dashboard-coredns.json
@@ -6,6 +6,7 @@
             "inputType": "select",
             "id": "ClusterName",
             "label": "Cluster name",
+            "defaultValue": "fleet-hub-cluster",
             "visible": true,
             "search": "{ContainerInsights/Prometheus,ClusterName} MetricName=coredns_dns_requests_total",
             "populateFrom": "ClusterName"

--- a/terraform/hub/cw-dashboard-karpenter.json
+++ b/terraform/hub/cw-dashboard-karpenter.json
@@ -6,9 +6,21 @@
             "inputType": "select",
             "id": "ClusterName",
             "label": "Cluster name",
+            "defaultValue": "fleet-hub-cluster",
             "visible": true,
             "search": "{ContainerInsights/Prometheus,ClusterName,nodepool,resource_type} MetricName=karpenter_nodepool_limit",
             "populateFrom": "ClusterName"
+        },
+        {
+            "type": "property",
+            "property": "nodepool",
+            "inputType": "select",
+            "id": "nodepool",
+            "label": "Node pool",
+            "defaultValue": "nodes-default-amd64-fleet-hub-cluster",
+            "visible": true,
+            "search": "ContainerInsights/Prometheus MetricName=karpenter_nodepool_limit",
+            "populateFrom": "nodepool"
         }
     ],
     "widgets": [

--- a/terraform/hub/cw-dashboard-vpc-cni.json
+++ b/terraform/hub/cw-dashboard-vpc-cni.json
@@ -6,6 +6,7 @@
             "inputType": "select",
             "id": "CLUSTER_ID",
             "label": "EKS Cluster",
+            "defaultValue": "fleet-hub-cluster",
             "visible": true,
             "search": "{Kubernetes,CLUSTER_ID} MetricName=assignIPAddresses",
             "populateFrom": "CLUSTER_ID"


### PR DESCRIPTION
… default for cluster dropdown in all dashboards

*Issue #, if available:*

*Description of changes:*
Make nodepool dynamic in karpenter dashboard and add a default for cluster dropdown in all dashboards

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
