### PR TITLE
hub to k8s 1.29 & karpenter dashboard

### DIFF
--- a/gitops/addons/charts/cw-prometheus/templates/prometheus-eks.yaml
+++ b/gitops/addons/charts/cw-prometheus/templates/prometheus-eks.yaml
@@ -40,6 +40,7 @@ data:
                     "^karpenter_nodes_total_pod_limits$",
                     "^karpenter_nodes_total_pod_requests$",
                     "^karpenter_pods_startup_time_seconds$",
+                    "^karpenter_pods_startup_duration_seconds$",
                     "^karpenter_cloudprovider_batcher_batch_size$",
                     "^karpenter_cloudprovider_batcher_batch_time_seconds$",
                     "^karpenter_cloudprovider_duration_seconds$",
@@ -77,7 +78,9 @@ data:
                   ],
                   "metric_selectors": [
                     "^karpenter_nodepool_limit$",
-                    "^karpenter_nodepool_usage$"
+                    "^karpenter_nodepools_limit$",
+                    "^karpenter_nodepool_usage$",
+                    "^karpenter_nodepools_usage$"
                   ]
                 },
                 {
@@ -92,6 +95,7 @@ data:
                     "^karpenter_nodeclaims_drifted$",
                     "^karpenter_nodeclaims_initialized$",
                     "^karpenter_nodeclaims_launched$",
+                    "^karpenter_nodeclaims_created_total$",
                     "^karpenter_nodeclaims_registered$",
                     "^karpenter_nodeclaims_terminated$"
                   ]
@@ -138,6 +142,7 @@ data:
       - role: endpoints
         namespaces:
           names:
+          - kube-system
           - karpenter
       relabel_configs:
       - source_labels: [__meta_kubernetes_endpoint_port_name]

--- a/gitops/addons/charts/resources/karpenter/templates/nodepool.yaml
+++ b/gitops/addons/charts/resources/karpenter/templates/nodepool.yaml
@@ -3,7 +3,7 @@
 apiVersion: karpenter.sh/{{ $.Values.ApiVersion }}
 kind: NodePool
 metadata:
-  name: "{{ $k }}-{{ $v.instances.architecture | default $.Values.instances.architecture }}-{{ $.Values.clusterName }}"
+  name: "{{ $k }}-{{ $v.instances.architecture | default $.Values.instances.architecture }}"
 spec:
   template:
     metadata:

--- a/terraform/hub/cw-dashboard-karpenter.json
+++ b/terraform/hub/cw-dashboard-karpenter.json
@@ -88,23 +88,6 @@
             }
         },
         {
-            "height": 6,
-            "width": 7,
-            "y": 6,
-            "x": 7,
-            "type": "metric",
-            "properties": {
-                "view": "timeSeries",
-                "stacked": false,
-                "region": "**aws_region**",
-                "metrics": [
-                    [ "ContainerInsights/Prometheus", "karpenter_nodeclaims_terminated", "nodepool", "nodes-default-amd64", "ClusterName", "${ClusterName}" ]
-                ],
-                "period": 300,
-                "stat": "Sum"
-            }
-        },
-        {
             "height": 3,
             "width": 7,
             "y": 0,

--- a/terraform/hub/cw-dashboard-karpenter.json
+++ b/terraform/hub/cw-dashboard-karpenter.json
@@ -8,7 +8,7 @@
             "label": "Cluster name",
             "defaultValue": "fleet-hub-cluster",
             "visible": true,
-            "search": "{ContainerInsights/Prometheus,ClusterName,nodepool,resource_type} MetricName=karpenter_nodepool_limit",
+            "search": "{ContainerInsights/Prometheus,ClusterName,nodepool,resource_type} MetricName=karpenter_nodepools_limit",
             "populateFrom": "ClusterName"
         },
         {
@@ -17,9 +17,9 @@
             "inputType": "select",
             "id": "nodepool",
             "label": "Node pool",
-            "defaultValue": "nodes-default-amd64-fleet-hub-cluster",
+            "defaultValue": "nodes-default-amd64",
             "visible": true,
-            "search": "ContainerInsights/Prometheus MetricName=karpenter_nodepool_limit",
+            "search": "ContainerInsights/Prometheus MetricName=karpenter_nodepools_limit",
             "populateFrom": "nodepool"
         }
     ],
@@ -34,10 +34,10 @@
                 "metrics": [
                     [ { "expression": "100*(m2/m1)", "label": "memory", "id": "e1" } ],
                     [ { "expression": "100*(m4/m3)", "label": "cpu", "id": "e2" } ],
-                    [ "ContainerInsights/Prometheus", "karpenter_nodepool_limit", "nodepool", "nodes-default-amd64", "resource_type", "memory", "ClusterName", "${ClusterName}", { "id": "m1", "visible": false } ],
-                    [ "ContainerInsights/Prometheus", "karpenter_nodepool_usage", "nodepool", "nodes-default-amd64", "resource_type", "memory", "ClusterName", "${ClusterName}", { "id": "m2", "visible": false } ],
-                    [ "ContainerInsights/Prometheus", "karpenter_nodepool_limit", "nodepool", "nodes-default-amd64", "resource_type", "cpu", "ClusterName", "${ClusterName}", { "id": "m3", "visible": false } ],
-                    [ "ContainerInsights/Prometheus", "karpenter_nodepool_usage", "nodepool", "nodes-default-amd64", "resource_type", "cpu", "ClusterName", "${ClusterName}", { "id": "m4", "visible": false } ]
+                    [ "ContainerInsights/Prometheus", "karpenter_nodepools_limit", "nodepool", "nodes-default-amd64", "resource_type", "memory", "ClusterName", "${ClusterName}", { "id": "m1", "visible": false } ],
+                    [ "ContainerInsights/Prometheus", "karpenter_nodepools_usage", "nodepool", "nodes-default-amd64", "resource_type", "memory", "ClusterName", "${ClusterName}", { "id": "m2", "visible": false } ],
+                    [ "ContainerInsights/Prometheus", "karpenter_nodepools_limit", "nodepool", "nodes-default-amd64", "resource_type", "cpu", "ClusterName", "${ClusterName}", { "id": "m3", "visible": false } ],
+                    [ "ContainerInsights/Prometheus", "karpenter_nodepools_usage", "nodepool", "nodes-default-amd64", "resource_type", "cpu", "ClusterName", "${ClusterName}", { "id": "m4", "visible": false } ]
                 ],
                 "sparkline": true,
                 "view": "gauge",
@@ -63,7 +63,7 @@
                 "view": "timeSeries",
                 "stacked": false,
                 "metrics": [
-                    [ "ContainerInsights/Prometheus", "karpenter_pods_startup_time_seconds", "ClusterName", "${ClusterName}" ]
+                    [ "ContainerInsights/Prometheus", "karpenter_pods_startup_duration_seconds", "ClusterName", "${ClusterName}" ]
                 ],
                 "region": "**aws_region**",
                 "period": 300,
@@ -78,7 +78,7 @@
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ "ContainerInsights/Prometheus", "karpenter_nodeclaims_launched", "nodepool", "nodes-default-amd64", "ClusterName", "${ClusterName}" ]
+                    [ "ContainerInsights/Prometheus", "karpenter_nodeclaims_created_total", "nodepool", "nodes-default-amd64", "ClusterName", "${ClusterName}" ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
@@ -114,8 +114,8 @@
                 "sparkline": true,
                 "view": "singleValue",
                 "metrics": [
-                    [ "ContainerInsights/Prometheus", "karpenter_nodepool_usage", "nodepool", "nodes-default-amd64", "resource_type", "memory", "ClusterName", "{ClusterName}" ],
-                    [ ".", "karpenter_nodepool_limit", ".", ".", ".", ".", ".", "." ]
+                    [ "ContainerInsights/Prometheus", "karpenter_nodepools_usage", "nodepool", "nodes-default-amd64", "resource_type", "memory", "ClusterName", "{ClusterName}" ],
+                    [ ".", "karpenter_nodepools_limit", ".", ".", ".", ".", ".", "." ]
                 ],
                 "region": "**aws_region**",
                 "singleValueFullPrecision": false,
@@ -134,8 +134,8 @@
                 "sparkline": true,
                 "view": "singleValue",
                 "metrics": [
-                    [ "ContainerInsights/Prometheus", "karpenter_nodepool_usage", "nodepool", "nodes-default-amd64", "resource_type", "cpu", "ClusterName", "{ClusterName}" ],
-                    [ ".", "karpenter_nodepool_limit", ".", ".", ".", ".", ".", "." ]
+                    [ "ContainerInsights/Prometheus", "karpenter_nodepools_usage", "nodepool", "nodes-default-amd64", "resource_type", "cpu", "ClusterName", "{ClusterName}" ],
+                    [ ".", "karpenter_nodepools_limit", ".", ".", ".", ".", ".", "." ]
                 ],
                 "region": "**aws_region**",
                 "stacked": true,

--- a/terraform/hub/variables.tf
+++ b/terraform/hub/variables.tf
@@ -7,7 +7,7 @@ variable "vpc_cidr" {
 variable "kubernetes_version" {
   description = "Kubernetes version"
   type        = string
-  default     = "1.30"
+  default     = "1.29"
 }
 
 variable "kms_key_admin_roles" {


### PR DESCRIPTION
- hub cluster version 1.29 to upgrade insights
- cloudwatch metrics for karpenter updated based on v1 and namespace