### PR TITLE
fix kyverno clusrrole for mutate policy

### DIFF
--- a/validation-frameworks/policy-testing/rbac-policy-mutation/clusterrole.yaml
+++ b/validation-frameworks/policy-testing/rbac-policy-mutation/clusterrole.yaml
@@ -11,8 +11,6 @@ rules:
   - apps
   resources:
   - deployments
-  resourceNames:
-  - "*"
   verbs:
   - get
   - list


### PR DESCRIPTION
- Fix the clusterrole policy specifying `*` for resourceNames is invalid
