### PR TITLE
CW observability - Drop unit attribute from metrics definition

### DIFF
--- a/terraform/hub/cw-dashboard-karpenter.json
+++ b/terraform/hub/cw-dashboard-karpenter.json
@@ -32,8 +32,8 @@
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ { "expression": "100*(m2/m1)", "label": "memory (%)", "id": "e1", "unit": "Percent" } ],
-                    [ { "expression": "100*(m4/m3)", "label": "cpu (%)", "id": "e2", "unit": "Percent" } ],
+                    [ { "expression": "100*(m2/m1)", "label": "memory (%)", "id": "e1" } ],
+                    [ { "expression": "100*(m4/m3)", "label": "cpu (%)", "id": "e2" } ],
                     [ "ContainerInsights/Prometheus", "karpenter_nodepools_limit", "nodepool", "nodes-default-amd64", "resource_type", "memory", "ClusterName", "${ClusterName}", { "id": "m1", "visible": false } ],
                     [ "ContainerInsights/Prometheus", "karpenter_nodepools_usage", "nodepool", "nodes-default-amd64", "resource_type", "memory", "ClusterName", "${ClusterName}", { "id": "m2", "visible": false } ],
                     [ "ContainerInsights/Prometheus", "karpenter_nodepools_limit", "nodepool", "nodes-default-amd64", "resource_type", "cpu", "ClusterName", "${ClusterName}", { "id": "m3", "visible": false } ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Drop the "unit" attribute from metrics definition in the dashboard JSON; it was causing the terraform to fail (although the JSON was accepted while attempted through the AWS console).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
