### PR TITLE
Add destroy option for QS fleet dashboard components

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -13,3 +13,4 @@ DEBUG=$DEBUG ${ROOTDIR}/terraform/hub/destroy.sh
 DEBUG=$DEBUG ${ROOTDIR}/terraform/spokes/destroy.sh staging
 DEBUG=$DEBUG ${ROOTDIR}/terraform/spokes/destroy.sh prod
 DEBUG=$DEBUG ${ROOTDIR}/terraform/common/destroy.sh
+DEBUG=$DEBUG ${ROOTDIR}/terraform/fleet-dashboard/destroy.sh

--- a/terraform/fleet-dashboard/destroy.sh
+++ b/terraform/fleet-dashboard/destroy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOTDIR="$(cd ${SCRIPTDIR}/..; pwd )"
+[[ -n "${DEBUG:-}" ]] && set -x
+
+echo "Destroying QuickSight Fleet dashboard resources"
+terraform -chdir=$SCRIPTDIR init --upgrade
+terraform -chdir=$SCRIPTDIR destroy -auto-approve
+destroy_output=$(terraform -chdir=$SCRIPTDIR  destroy -auto-approve 2>&1)


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*  To destroy QuickSight related fleet dashboard components deployed by Terraform 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
