### PR TITLE
fix(adot-collector) Fix port conflict

### DIFF
--- a/gitops/addons/charts/adot-collector/templates/opentelemetrycollector.yaml
+++ b/gitops/addons/charts/adot-collector/templates/opentelemetrycollector.yaml
@@ -34,7 +34,7 @@ spec:
           - job_name: otel-collector-metrics
             scrape_interval: 10s
             static_configs:
-              - targets: ['localhost:8888']
+              - targets: ['localhost:{{ .Values.telemetryPort }}']
       {{ end }}
       prometheus:
         config:
@@ -422,7 +422,7 @@ spec:
       {{ if .Values.enableAdotcollectorMetrics }}
       telemetry:
         metrics:
-          address: 0.0.0.0:8888
+          address: 0.0.0.0:{{ .Values.telemetryPort }}
           level: basic
         logs:
           level: {{ .Values.adotServiceTelemetryLoglevel }}

--- a/gitops/addons/charts/adot-collector/values.yaml
+++ b/gitops/addons/charts/adot-collector/values.yaml
@@ -34,7 +34,9 @@ enableIstio: false
 adotLoglevel: normal
 adotServiceTelemetryLoglevel: INFO
 
-enableAdotcollectorMetrics: false
+# override default port to avoid conflict with grafana port
+enableAdotcollectorMetrics: true
+telemetryPort: 8889
 
 serviceAccount: "adot-collector-kubeprometheus"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Without this, `adot-collector` crash loopbackoff because 8888 port is already used by Grafana.

Workshop module: https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/module-04-observability/open-source

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
