### PR TITLE
Remove hardcoded credentials and real account ids

### DIFF
--- a/gitops/apps/backend/rabbitmq/base/generated.yaml
+++ b/gitops/apps/backend/rabbitmq/base/generated.yaml
@@ -43,9 +43,13 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  rabbitmq-password: "d282NkZHRjV0RWFJNDU0RA=="
+  # Placeholder values: both decode to CHANGE_ME. Generate your own before
+  # applying this manifest, for example:
+  #   printf %s "$(openssl rand -base64 16)" | base64   # rabbitmq-password
+  #   printf %s "$(openssl rand -base64 32)" | base64   # rabbitmq-erlang-cookie
+  rabbitmq-password: "Q0hBTkdFX01F"
   
-  rabbitmq-erlang-cookie: "WnFkT1lqR0cyZ29NVWdiaUFwbHRDendabkRrZ0ZqVjU="
+  rabbitmq-erlang-cookie: "Q0hBTkdFX01F"
 ---
 # Source: rabbitmq/templates/role.yaml
 kind: Role

--- a/patterns/kro-eks-cluster-mgmt/apps/backend/rabbitmq/base/generated.yaml
+++ b/patterns/kro-eks-cluster-mgmt/apps/backend/rabbitmq/base/generated.yaml
@@ -43,9 +43,13 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  rabbitmq-password: "d282NkZHRjV0RWFJNDU0RA=="
+  # Placeholder values: both decode to CHANGE_ME. Generate your own before
+  # applying this manifest, for example:
+  #   printf %s "$(openssl rand -base64 16)" | base64   # rabbitmq-password
+  #   printf %s "$(openssl rand -base64 32)" | base64   # rabbitmq-erlang-cookie
+  rabbitmq-password: "Q0hBTkdFX01F"
   
-  rabbitmq-erlang-cookie: "WnFkT1lqR0cyZ29NVWdiaUFwbHRDendabkRrZ0ZqVjU="
+  rabbitmq-erlang-cookie: "Q0hBTkdFX01F"
 ---
 # Source: rabbitmq/templates/role.yaml
 kind: Role

--- a/patterns/kro-eks-cluster-mgmt/charts/backstage/templates/install.yaml
+++ b/patterns/kro-eks-cluster-mgmt/charts/backstage/templates/install.yaml
@@ -153,7 +153,10 @@ data:
     auth:
       environment: development
       session:
-        secret: MW2sV-sIPngEl26vAzatV-6VqfsgAx4bPIz7PuE_2Lk=
+        # Read from the environment, like KEYCLOAK_CLIENT_SECRET below.
+        # Generate a value per install, for example:
+        #   openssl rand -base64 32
+        secret: ${BACKSTAGE_SESSION_SECRET}
       providers:
         keycloak-oidc:
           development:

--- a/patterns/kro-eks-cluster-mgmt/charts/pod-identity/values.yaml
+++ b/patterns/kro-eks-cluster-mgmt/charts/pod-identity/values.yaml
@@ -1,5 +1,5 @@
 # region: us-west-2
-# accountId: "471112582304"
+# accountId: "111122223333"
 # create: true
 # podIdentityPolicyCreate: false
 # podIdentityRole:

--- a/patterns/kro-eks-cluster-mgmt/scripts/4-deploy-argo-rollouts-demo.sh
+++ b/patterns/kro-eks-cluster-mgmt/scripts/4-deploy-argo-rollouts-demo.sh
@@ -46,10 +46,15 @@ print_step "Creating Amazon Elastic Container Repository (Amazon ECR) for contai
 aws ecr create-repository --repository-name rollouts-demo --region $AWS_REGION || true
 
 print_step "Setting up cross-account permissions for ECR repository"
-# Define spoke account IDs - if not already defined, use the provided accounts
+# Spoke account IDs. There is deliberately no default: these ids are used
+# below to build an ECR repository policy that grants cross-account pull,
+# so a default would silently grant access to accounts the operator does
+# not control.
 if [ -z "$SPOKE_ACCOUNT_IDS" ]; then
-  export SPOKE_ACCOUNT_IDS="515966522948 586794472760 825765380480"
-  print_info "Using default SPOKE_ACCOUNT_IDS: $SPOKE_ACCOUNT_IDS"
+  print_error "SPOKE_ACCOUNT_IDS is not set."
+  print_info  "Set it to your own spoke account ids before running this script:"
+  print_info  '  export SPOKE_ACCOUNT_IDS="111122223333 444455556666 777788889999"'
+  exit 1
 fi
 
 # Create policy statements for each spoke account


### PR DESCRIPTION
While vendoring part of this workshop into another AWS sample I ran a credential scan over `mainline` and found four items worth fixing. Values are described by file and line rather than restated here.

## The one with real impact

`patterns/kro-eks-cluster-mgmt/scripts/4-deploy-argo-rollouts-demo.sh:50-53` defaults `SPOKE_ACCOUNT_IDS` to three real twelve-digit account ids. Those ids are consumed a few lines below, at line 57, to build an ECR repository policy that grants cross-account pull.

So an operator who runs the script without setting the variable, which the code path explicitly supports, grants three accounts they do not control read access to their own ECR repository. That is a silent outcome: the script prints the ids it is using and continues.

The default is removed. The script now fails with an explicit instruction and a placeholder example, which seems safer than any default for a value that ends up in a resource policy.

## Hardcoded secrets

| Location | Value |
|---|---|
| `patterns/kro-eks-cluster-mgmt/charts/backstage/templates/install.yaml:156` | Backstage `auth.session.secret`, a generated 32-byte value committed in the clear |
| `patterns/kro-eks-cluster-mgmt/apps/backend/rabbitmq/base/generated.yaml:46,48` | RabbitMQ password and Erlang cookie, generated values |
| `gitops/apps/backend/rabbitmq/base/generated.yaml:46,48` | the same two, duplicated in this tree |

The Backstage one now reads from the environment, which is the pattern the very next lines of that file already use for `KEYCLOAK_CLIENT_SECRET`. The RabbitMQ pair becomes `CHANGE_ME` placeholders with a comment showing how to generate real values.

Since these were public, you may want to treat them as compromised and rotate anywhere they were reused, independently of this PR.

## Minor

`patterns/kro-eks-cluster-mgmt/charts/pod-identity/values.yaml:2` carries a fourth account id in a commented-out example. Switched to the documentation placeholder range.

## Out of scope on purpose

`apps/backend/{orders,catalog}/base/secrets.yaml` carry a `default_password`. That reads like an intentional demo default rather than a leak, so I left it alone to keep this diff focused. Happy to include it if you would rather it were a placeholder too.

## Notes

Five files, no functional change beyond the script now requiring a variable it previously guessed. I have not run the pattern end to end, so the Backstage change needs `BACKSTAGE_SESSION_SECRET` wired wherever that chart is templated: point me at the right place and I will add it here.
